### PR TITLE
test: improve test coverage across all SDK modules

### DIFF
--- a/Tests/AlgoKitTests/ApplicationTransactionTests.swift
+++ b/Tests/AlgoKitTests/ApplicationTransactionTests.swift
@@ -1,0 +1,420 @@
+import XCTest
+@testable import AlgoKit
+import Algorand
+
+final class ApplicationTransactionTests: XCTestCase {
+
+    private let genesisID = "testnet-v1.0"
+    private let genesisHash = Data(repeating: 0, count: 32)
+
+    private func makeAccount() throws -> Account {
+        let algokit = AlgoKit(network: .testnet)
+        return try algokit.generateAccount()
+    }
+
+    // MARK: - Application Call (NoOp)
+
+    func test_applicationCall_buildsWithArguments() throws {
+        let caller = try makeAccount()
+        let arg1 = "hello".data(using: .utf8)!
+        let arg2 = "world".data(using: .utf8)!
+
+        let tx = ApplicationCallTransaction.call(
+            sender: caller.address,
+            applicationID: 12345,
+            appArguments: [arg1, arg2],
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, caller.address)
+        XCTAssertEqual(tx.applicationID, 12345)
+    }
+
+    func test_applicationCall_buildsWithoutArguments() throws {
+        let caller = try makeAccount()
+
+        let tx = ApplicationCallTransaction.call(
+            sender: caller.address,
+            applicationID: 99999,
+            firstValid: 500,
+            lastValid: 1500,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.applicationID, 99999)
+    }
+
+    func test_applicationCall_withForeignApps() throws {
+        let caller = try makeAccount()
+
+        let tx = ApplicationCallTransaction.call(
+            sender: caller.address,
+            applicationID: 12345,
+            foreignApps: [111, 222, 333],
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, caller.address)
+        XCTAssertEqual(tx.applicationID, 12345)
+    }
+
+    func test_applicationCall_withForeignAssets() throws {
+        let caller = try makeAccount()
+
+        let tx = ApplicationCallTransaction.call(
+            sender: caller.address,
+            applicationID: 12345,
+            foreignAssets: [444, 555],
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, caller.address)
+    }
+
+    func test_applicationCall_withAccounts() throws {
+        let caller = try makeAccount()
+        let extra = try makeAccount()
+
+        let tx = ApplicationCallTransaction.call(
+            sender: caller.address,
+            applicationID: 12345,
+            accounts: [extra.address],
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, caller.address)
+    }
+
+    // MARK: - Application Opt-In
+
+    func test_applicationOptIn_buildsCorrectly() throws {
+        let account = try makeAccount()
+
+        let tx = ApplicationCallTransaction.optIn(
+            sender: account.address,
+            applicationID: 67890,
+            firstValid: 100,
+            lastValid: 1100,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, account.address)
+        XCTAssertEqual(tx.applicationID, 67890)
+    }
+
+    func test_applicationOptIn_withArguments() throws {
+        let account = try makeAccount()
+        let arg = "opt-in-data".data(using: .utf8)!
+
+        let tx = ApplicationCallTransaction.optIn(
+            sender: account.address,
+            applicationID: 67890,
+            appArguments: [arg],
+            firstValid: 100,
+            lastValid: 1100,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.applicationID, 67890)
+    }
+
+    // MARK: - Application Close Out
+
+    func test_applicationCloseOut_buildsCorrectly() throws {
+        let account = try makeAccount()
+
+        let tx = ApplicationCallTransaction.closeOut(
+            sender: account.address,
+            applicationID: 11111,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, account.address)
+        XCTAssertEqual(tx.applicationID, 11111)
+    }
+
+    func test_applicationCloseOut_withArguments() throws {
+        let account = try makeAccount()
+        let arg = "close-data".data(using: .utf8)!
+
+        let tx = ApplicationCallTransaction.closeOut(
+            sender: account.address,
+            applicationID: 11111,
+            appArguments: [arg],
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.applicationID, 11111)
+    }
+
+    // MARK: - Application Update
+
+    func test_applicationUpdate_buildsCorrectly() throws {
+        let account = try makeAccount()
+        let approval = Data([0x01, 0x20, 0x01, 0x01, 0x22])
+        let clearState = Data([0x01, 0x20, 0x01, 0x01, 0x22])
+
+        let tx = ApplicationCallTransaction.update(
+            sender: account.address,
+            applicationID: 22222,
+            approvalProgram: approval,
+            clearStateProgram: clearState,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, account.address)
+        XCTAssertEqual(tx.applicationID, 22222)
+    }
+
+    func test_applicationUpdate_withArguments() throws {
+        let account = try makeAccount()
+        let approval = Data([0x01])
+        let clearState = Data([0x01])
+        let arg = "update-arg".data(using: .utf8)!
+
+        let tx = ApplicationCallTransaction.update(
+            sender: account.address,
+            applicationID: 22222,
+            approvalProgram: approval,
+            clearStateProgram: clearState,
+            appArguments: [arg],
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.applicationID, 22222)
+    }
+
+    // MARK: - Application Delete
+
+    func test_applicationDelete_buildsCorrectly() throws {
+        let account = try makeAccount()
+
+        let tx = ApplicationCallTransaction.delete(
+            sender: account.address,
+            applicationID: 33333,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, account.address)
+        XCTAssertEqual(tx.applicationID, 33333)
+    }
+
+    func test_applicationDelete_withArguments() throws {
+        let account = try makeAccount()
+        let arg = "delete-arg".data(using: .utf8)!
+
+        let tx = ApplicationCallTransaction.delete(
+            sender: account.address,
+            applicationID: 33333,
+            appArguments: [arg],
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.applicationID, 33333)
+    }
+
+    // MARK: - Application Create
+
+    func test_applicationCreate_buildsCorrectly() throws {
+        let creator = try makeAccount()
+        let approval = Data([0x01, 0x20, 0x01, 0x01, 0x22])
+        let clearState = Data([0x01, 0x20, 0x01, 0x01, 0x22])
+
+        let tx = ApplicationCallTransaction.create(
+            sender: creator.address,
+            approvalProgram: approval,
+            clearStateProgram: clearState,
+            globalStateSchema: StateSchema(numUint: 1, numByteSlice: 1),
+            localStateSchema: StateSchema(numUint: 0, numByteSlice: 0),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, creator.address)
+    }
+
+    func test_applicationCreate_withExtraPages() throws {
+        let creator = try makeAccount()
+        let approval = Data(repeating: 0x01, count: 100)
+        let clearState = Data([0x01])
+
+        let tx = ApplicationCallTransaction.create(
+            sender: creator.address,
+            approvalProgram: approval,
+            clearStateProgram: clearState,
+            globalStateSchema: StateSchema(numUint: 10, numByteSlice: 5),
+            localStateSchema: StateSchema(numUint: 2, numByteSlice: 1),
+            extraPages: 1,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, creator.address)
+    }
+
+    func test_applicationCreate_withArguments() throws {
+        let creator = try makeAccount()
+        let approval = Data([0x01])
+        let clearState = Data([0x01])
+        let arg = "init".data(using: .utf8)!
+
+        let tx = ApplicationCallTransaction.create(
+            sender: creator.address,
+            approvalProgram: approval,
+            clearStateProgram: clearState,
+            globalStateSchema: StateSchema(numUint: 1, numByteSlice: 0),
+            localStateSchema: StateSchema(numUint: 0, numByteSlice: 0),
+            appArguments: [arg],
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, creator.address)
+    }
+
+    // MARK: - Transaction Signing
+
+    func test_applicationCall_canBeSigned() throws {
+        let caller = try makeAccount()
+
+        let tx = ApplicationCallTransaction.call(
+            sender: caller.address,
+            applicationID: 12345,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: caller)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    func test_applicationOptIn_canBeSigned() throws {
+        let account = try makeAccount()
+
+        let tx = ApplicationCallTransaction.optIn(
+            sender: account.address,
+            applicationID: 12345,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: account)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    func test_applicationCloseOut_canBeSigned() throws {
+        let account = try makeAccount()
+
+        let tx = ApplicationCallTransaction.closeOut(
+            sender: account.address,
+            applicationID: 12345,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: account)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    func test_applicationDelete_canBeSigned() throws {
+        let account = try makeAccount()
+
+        let tx = ApplicationCallTransaction.delete(
+            sender: account.address,
+            applicationID: 12345,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: account)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    func test_applicationUpdate_canBeSigned() throws {
+        let account = try makeAccount()
+        let approval = Data([0x01])
+        let clearState = Data([0x01])
+
+        let tx = ApplicationCallTransaction.update(
+            sender: account.address,
+            applicationID: 12345,
+            approvalProgram: approval,
+            clearStateProgram: clearState,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: account)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    func test_applicationCreate_canBeSigned() throws {
+        let creator = try makeAccount()
+        let approval = Data([0x01])
+        let clearState = Data([0x01])
+
+        let tx = ApplicationCallTransaction.create(
+            sender: creator.address,
+            approvalProgram: approval,
+            clearStateProgram: clearState,
+            globalStateSchema: StateSchema(numUint: 1, numByteSlice: 0),
+            localStateSchema: StateSchema(numUint: 0, numByteSlice: 0),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: creator)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+}

--- a/Tests/AlgoKitTests/ApplicationTransactionTests.swift
+++ b/Tests/AlgoKitTests/ApplicationTransactionTests.swift
@@ -7,15 +7,15 @@ final class ApplicationTransactionTests: XCTestCase {
     private let genesisID = "testnet-v1.0"
     private let genesisHash = Data(repeating: 0, count: 32)
 
-    private func makeAccount() throws -> Account {
+    private func makeAccount() async throws -> Account {
         let algokit = AlgoKit(network: .testnet)
-        return try algokit.generateAccount()
+        return try await algokit.generateAccount()
     }
 
     // MARK: - Application Call (NoOp)
 
-    func test_applicationCall_buildsWithArguments() throws {
-        let caller = try makeAccount()
+    func test_applicationCall_buildsWithArguments() async throws {
+        let caller = try await makeAccount()
         let arg1 = "hello".data(using: .utf8)!
         let arg2 = "world".data(using: .utf8)!
 
@@ -33,8 +33,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.applicationID, 12345)
     }
 
-    func test_applicationCall_buildsWithoutArguments() throws {
-        let caller = try makeAccount()
+    func test_applicationCall_buildsWithoutArguments() async throws {
+        let caller = try await makeAccount()
 
         let tx = ApplicationCallTransaction.call(
             sender: caller.address,
@@ -48,8 +48,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.applicationID, 99999)
     }
 
-    func test_applicationCall_withForeignApps() throws {
-        let caller = try makeAccount()
+    func test_applicationCall_withForeignApps() async throws {
+        let caller = try await makeAccount()
 
         let tx = ApplicationCallTransaction.call(
             sender: caller.address,
@@ -65,8 +65,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.applicationID, 12345)
     }
 
-    func test_applicationCall_withForeignAssets() throws {
-        let caller = try makeAccount()
+    func test_applicationCall_withForeignAssets() async throws {
+        let caller = try await makeAccount()
 
         let tx = ApplicationCallTransaction.call(
             sender: caller.address,
@@ -81,9 +81,9 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.sender, caller.address)
     }
 
-    func test_applicationCall_withAccounts() throws {
-        let caller = try makeAccount()
-        let extra = try makeAccount()
+    func test_applicationCall_withAccounts() async throws {
+        let caller = try await makeAccount()
+        let extra = try await makeAccount()
 
         let tx = ApplicationCallTransaction.call(
             sender: caller.address,
@@ -100,8 +100,8 @@ final class ApplicationTransactionTests: XCTestCase {
 
     // MARK: - Application Opt-In
 
-    func test_applicationOptIn_buildsCorrectly() throws {
-        let account = try makeAccount()
+    func test_applicationOptIn_buildsCorrectly() async throws {
+        let account = try await makeAccount()
 
         let tx = ApplicationCallTransaction.optIn(
             sender: account.address,
@@ -116,8 +116,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.applicationID, 67890)
     }
 
-    func test_applicationOptIn_withArguments() throws {
-        let account = try makeAccount()
+    func test_applicationOptIn_withArguments() async throws {
+        let account = try await makeAccount()
         let arg = "opt-in-data".data(using: .utf8)!
 
         let tx = ApplicationCallTransaction.optIn(
@@ -135,8 +135,8 @@ final class ApplicationTransactionTests: XCTestCase {
 
     // MARK: - Application Close Out
 
-    func test_applicationCloseOut_buildsCorrectly() throws {
-        let account = try makeAccount()
+    func test_applicationCloseOut_buildsCorrectly() async throws {
+        let account = try await makeAccount()
 
         let tx = ApplicationCallTransaction.closeOut(
             sender: account.address,
@@ -151,8 +151,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.applicationID, 11111)
     }
 
-    func test_applicationCloseOut_withArguments() throws {
-        let account = try makeAccount()
+    func test_applicationCloseOut_withArguments() async throws {
+        let account = try await makeAccount()
         let arg = "close-data".data(using: .utf8)!
 
         let tx = ApplicationCallTransaction.closeOut(
@@ -170,8 +170,8 @@ final class ApplicationTransactionTests: XCTestCase {
 
     // MARK: - Application Update
 
-    func test_applicationUpdate_buildsCorrectly() throws {
-        let account = try makeAccount()
+    func test_applicationUpdate_buildsCorrectly() async throws {
+        let account = try await makeAccount()
         let approval = Data([0x01, 0x20, 0x01, 0x01, 0x22])
         let clearState = Data([0x01, 0x20, 0x01, 0x01, 0x22])
 
@@ -190,8 +190,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.applicationID, 22222)
     }
 
-    func test_applicationUpdate_withArguments() throws {
-        let account = try makeAccount()
+    func test_applicationUpdate_withArguments() async throws {
+        let account = try await makeAccount()
         let approval = Data([0x01])
         let clearState = Data([0x01])
         let arg = "update-arg".data(using: .utf8)!
@@ -213,8 +213,8 @@ final class ApplicationTransactionTests: XCTestCase {
 
     // MARK: - Application Delete
 
-    func test_applicationDelete_buildsCorrectly() throws {
-        let account = try makeAccount()
+    func test_applicationDelete_buildsCorrectly() async throws {
+        let account = try await makeAccount()
 
         let tx = ApplicationCallTransaction.delete(
             sender: account.address,
@@ -229,8 +229,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.applicationID, 33333)
     }
 
-    func test_applicationDelete_withArguments() throws {
-        let account = try makeAccount()
+    func test_applicationDelete_withArguments() async throws {
+        let account = try await makeAccount()
         let arg = "delete-arg".data(using: .utf8)!
 
         let tx = ApplicationCallTransaction.delete(
@@ -248,8 +248,8 @@ final class ApplicationTransactionTests: XCTestCase {
 
     // MARK: - Application Create
 
-    func test_applicationCreate_buildsCorrectly() throws {
-        let creator = try makeAccount()
+    func test_applicationCreate_buildsCorrectly() async throws {
+        let creator = try await makeAccount()
         let approval = Data([0x01, 0x20, 0x01, 0x01, 0x22])
         let clearState = Data([0x01, 0x20, 0x01, 0x01, 0x22])
 
@@ -268,8 +268,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.sender, creator.address)
     }
 
-    func test_applicationCreate_withExtraPages() throws {
-        let creator = try makeAccount()
+    func test_applicationCreate_withExtraPages() async throws {
+        let creator = try await makeAccount()
         let approval = Data(repeating: 0x01, count: 100)
         let clearState = Data([0x01])
 
@@ -289,8 +289,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertEqual(tx.sender, creator.address)
     }
 
-    func test_applicationCreate_withArguments() throws {
-        let creator = try makeAccount()
+    func test_applicationCreate_withArguments() async throws {
+        let creator = try await makeAccount()
         let approval = Data([0x01])
         let clearState = Data([0x01])
         let arg = "init".data(using: .utf8)!
@@ -313,8 +313,8 @@ final class ApplicationTransactionTests: XCTestCase {
 
     // MARK: - Transaction Signing
 
-    func test_applicationCall_canBeSigned() throws {
-        let caller = try makeAccount()
+    func test_applicationCall_canBeSigned() async throws {
+        let caller = try await makeAccount()
 
         let tx = ApplicationCallTransaction.call(
             sender: caller.address,
@@ -329,8 +329,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertFalse(signed.signature.isEmpty)
     }
 
-    func test_applicationOptIn_canBeSigned() throws {
-        let account = try makeAccount()
+    func test_applicationOptIn_canBeSigned() async throws {
+        let account = try await makeAccount()
 
         let tx = ApplicationCallTransaction.optIn(
             sender: account.address,
@@ -345,8 +345,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertFalse(signed.signature.isEmpty)
     }
 
-    func test_applicationCloseOut_canBeSigned() throws {
-        let account = try makeAccount()
+    func test_applicationCloseOut_canBeSigned() async throws {
+        let account = try await makeAccount()
 
         let tx = ApplicationCallTransaction.closeOut(
             sender: account.address,
@@ -361,8 +361,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertFalse(signed.signature.isEmpty)
     }
 
-    func test_applicationDelete_canBeSigned() throws {
-        let account = try makeAccount()
+    func test_applicationDelete_canBeSigned() async throws {
+        let account = try await makeAccount()
 
         let tx = ApplicationCallTransaction.delete(
             sender: account.address,
@@ -377,8 +377,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertFalse(signed.signature.isEmpty)
     }
 
-    func test_applicationUpdate_canBeSigned() throws {
-        let account = try makeAccount()
+    func test_applicationUpdate_canBeSigned() async throws {
+        let account = try await makeAccount()
         let approval = Data([0x01])
         let clearState = Data([0x01])
 
@@ -397,8 +397,8 @@ final class ApplicationTransactionTests: XCTestCase {
         XCTAssertFalse(signed.signature.isEmpty)
     }
 
-    func test_applicationCreate_canBeSigned() throws {
-        let creator = try makeAccount()
+    func test_applicationCreate_canBeSigned() async throws {
+        let creator = try await makeAccount()
         let approval = Data([0x01])
         let clearState = Data([0x01])
 

--- a/Tests/AlgoKitTests/AssetTransactionTests.swift
+++ b/Tests/AlgoKitTests/AssetTransactionTests.swift
@@ -1,0 +1,420 @@
+import XCTest
+@testable import AlgoKit
+import Algorand
+
+final class AssetTransactionTests: XCTestCase {
+
+    private let genesisID = "testnet-v1.0"
+    private let genesisHash = Data(repeating: 0, count: 32)
+
+    private func makeAccount() throws -> Account {
+        let algokit = AlgoKit(network: .testnet)
+        return try algokit.generateAccount()
+    }
+
+    // MARK: - Asset Create Transaction
+
+    func test_assetCreate_withFullParams() throws {
+        let creator = try makeAccount()
+        let manager = try makeAccount()
+        let reserve = try makeAccount()
+        let freeze = try makeAccount()
+        let clawback = try makeAccount()
+
+        let assetParams = AssetParams(
+            total: 10_000_000,
+            decimals: 8,
+            unitName: "FULL",
+            assetName: "Full Asset",
+            url: "https://example.com",
+            manager: manager.address,
+            reserve: reserve.address,
+            freeze: freeze.address,
+            clawback: clawback.address
+        )
+
+        let tx = AssetCreateTransaction(
+            sender: creator.address,
+            assetParams: assetParams,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, creator.address)
+        XCTAssertEqual(tx.assetParams.total, 10_000_000)
+        XCTAssertEqual(tx.assetParams.decimals, 8)
+        XCTAssertEqual(tx.assetParams.unitName, "FULL")
+        XCTAssertEqual(tx.assetParams.assetName, "Full Asset")
+    }
+
+    func test_assetCreate_nftParams() throws {
+        let creator = try makeAccount()
+
+        let assetParams = AssetParams(
+            total: 1,
+            decimals: 0,
+            unitName: "NFT",
+            assetName: "My NFT",
+            url: "ipfs://QmTest",
+            manager: creator.address,
+            reserve: creator.address
+        )
+
+        let tx = AssetCreateTransaction(
+            sender: creator.address,
+            assetParams: assetParams,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.assetParams.total, 1)
+        XCTAssertEqual(tx.assetParams.decimals, 0)
+    }
+
+    func test_assetCreate_withMetadataHash() throws {
+        let creator = try makeAccount()
+        let metadataHash = Data(repeating: 0xAB, count: 32)
+
+        let assetParams = AssetParams(
+            total: 1000,
+            decimals: 0,
+            unitName: "META",
+            assetName: "Meta Asset",
+            metadataHash: metadataHash,
+            manager: creator.address,
+            reserve: creator.address
+        )
+
+        let tx = AssetCreateTransaction(
+            sender: creator.address,
+            assetParams: assetParams,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.assetParams.metadataHash, metadataHash)
+    }
+
+    func test_assetCreate_canBeSigned() throws {
+        let creator = try makeAccount()
+
+        let assetParams = AssetParams(
+            total: 1000,
+            decimals: 0,
+            unitName: "SIGN",
+            assetName: "Signable",
+            manager: creator.address,
+            reserve: creator.address
+        )
+
+        let tx = AssetCreateTransaction(
+            sender: creator.address,
+            assetParams: assetParams,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: creator)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    // MARK: - Asset Opt-In Transaction
+
+    func test_assetOptIn_setsCorrectFields() throws {
+        let account = try makeAccount()
+
+        let tx = AssetOptInTransaction(
+            sender: account.address,
+            assetID: 99999,
+            firstValid: 500,
+            lastValid: 1500,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, account.address)
+        XCTAssertEqual(tx.assetID, 99999)
+    }
+
+    func test_assetOptIn_canBeSigned() throws {
+        let account = try makeAccount()
+
+        let tx = AssetOptInTransaction(
+            sender: account.address,
+            assetID: 12345,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: account)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    // MARK: - Asset Transfer Transaction
+
+    func test_assetTransfer_buildsCorrectly() throws {
+        let sender = try makeAccount()
+        let receiver = try makeAccount()
+
+        let tx = AssetTransferTransaction(
+            sender: sender.address,
+            receiver: receiver.address,
+            assetID: 54321,
+            amount: 500,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, sender.address)
+        XCTAssertEqual(tx.receiver, receiver.address)
+        XCTAssertEqual(tx.assetID, 54321)
+        XCTAssertEqual(tx.amount, 500)
+    }
+
+    func test_assetTransfer_withCloseRemainder() throws {
+        let sender = try makeAccount()
+        let receiver = try makeAccount()
+        let closeTarget = try makeAccount()
+
+        let tx = AssetTransferTransaction(
+            sender: sender.address,
+            receiver: receiver.address,
+            assetID: 54321,
+            amount: 0,
+            closeRemainderTo: closeTarget.address,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.amount, 0)
+        XCTAssertEqual(tx.closeRemainderTo, closeTarget.address)
+    }
+
+    func test_assetTransfer_zeroAmount() throws {
+        let sender = try makeAccount()
+        let receiver = try makeAccount()
+
+        let tx = AssetTransferTransaction(
+            sender: sender.address,
+            receiver: receiver.address,
+            assetID: 12345,
+            amount: 0,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.amount, 0)
+    }
+
+    func test_assetTransfer_largeAmount() throws {
+        let sender = try makeAccount()
+        let receiver = try makeAccount()
+
+        let tx = AssetTransferTransaction(
+            sender: sender.address,
+            receiver: receiver.address,
+            assetID: 12345,
+            amount: UInt64.max,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.amount, UInt64.max)
+    }
+
+    func test_assetTransfer_canBeSigned() throws {
+        let sender = try makeAccount()
+        let receiver = try makeAccount()
+
+        let tx = AssetTransferTransaction(
+            sender: sender.address,
+            receiver: receiver.address,
+            assetID: 12345,
+            amount: 100,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: sender)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    // MARK: - Asset Freeze Transaction
+
+    func test_assetFreeze_freezeAccount() throws {
+        let freezeAuthority = try makeAccount()
+        let target = try makeAccount()
+
+        let tx = AssetFreezeTransaction(
+            sender: freezeAuthority.address,
+            assetID: 12345,
+            freezeAccount: target.address,
+            frozen: true,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, freezeAuthority.address)
+        XCTAssertEqual(tx.assetID, 12345)
+        XCTAssertEqual(tx.freezeAccount, target.address)
+        XCTAssertTrue(tx.frozen)
+    }
+
+    func test_assetFreeze_unfreezeAccount() throws {
+        let freezeAuthority = try makeAccount()
+        let target = try makeAccount()
+
+        let tx = AssetFreezeTransaction(
+            sender: freezeAuthority.address,
+            assetID: 12345,
+            freezeAccount: target.address,
+            frozen: false,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertFalse(tx.frozen)
+    }
+
+    func test_assetFreeze_canBeSigned() throws {
+        let freezeAuthority = try makeAccount()
+        let target = try makeAccount()
+
+        let tx = AssetFreezeTransaction(
+            sender: freezeAuthority.address,
+            assetID: 12345,
+            freezeAccount: target.address,
+            frozen: true,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: freezeAuthority)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    // MARK: - Asset Config Transaction
+
+    func test_assetConfig_update() throws {
+        let manager = try makeAccount()
+        let newManager = try makeAccount()
+
+        let tx = AssetConfigTransaction.update(
+            sender: manager.address,
+            assetID: 12345,
+            manager: newManager.address,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, manager.address)
+        XCTAssertEqual(tx.assetID, 12345)
+    }
+
+    func test_assetConfig_destroy() throws {
+        let manager = try makeAccount()
+
+        let tx = AssetConfigTransaction.destroy(
+            sender: manager.address,
+            assetID: 12345,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, manager.address)
+        XCTAssertEqual(tx.assetID, 12345)
+    }
+
+    func test_assetConfig_canBeSigned() throws {
+        let manager = try makeAccount()
+
+        let tx = AssetConfigTransaction.update(
+            sender: manager.address,
+            assetID: 12345,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: manager)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    // MARK: - Asset Clawback Transaction
+
+    func test_assetClawback_buildsCorrectly() throws {
+        let clawbackAuth = try makeAccount()
+        let target = try makeAccount()
+        let destination = try makeAccount()
+
+        let tx = AssetClawbackTransaction(
+            sender: clawbackAuth.address,
+            assetID: 12345,
+            assetSender: target.address,
+            assetReceiver: destination.address,
+            amount: 500,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        XCTAssertEqual(tx.sender, clawbackAuth.address)
+        XCTAssertEqual(tx.assetID, 12345)
+        XCTAssertEqual(tx.assetSender, target.address)
+        XCTAssertEqual(tx.assetReceiver, destination.address)
+        XCTAssertEqual(tx.amount, 500)
+    }
+
+    func test_assetClawback_canBeSigned() throws {
+        let clawbackAuth = try makeAccount()
+        let target = try makeAccount()
+        let destination = try makeAccount()
+
+        let tx = AssetClawbackTransaction(
+            sender: clawbackAuth.address,
+            assetID: 12345,
+            assetSender: target.address,
+            assetReceiver: destination.address,
+            amount: 100,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: clawbackAuth)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+}

--- a/Tests/AlgoKitTests/AssetTransactionTests.swift
+++ b/Tests/AlgoKitTests/AssetTransactionTests.swift
@@ -7,19 +7,19 @@ final class AssetTransactionTests: XCTestCase {
     private let genesisID = "testnet-v1.0"
     private let genesisHash = Data(repeating: 0, count: 32)
 
-    private func makeAccount() throws -> Account {
+    private func makeAccount() async throws -> Account {
         let algokit = AlgoKit(network: .testnet)
-        return try algokit.generateAccount()
+        return try await algokit.generateAccount()
     }
 
     // MARK: - Asset Create Transaction
 
-    func test_assetCreate_withFullParams() throws {
-        let creator = try makeAccount()
-        let manager = try makeAccount()
-        let reserve = try makeAccount()
-        let freeze = try makeAccount()
-        let clawback = try makeAccount()
+    func test_assetCreate_withFullParams() async throws {
+        let creator = try await makeAccount()
+        let manager = try await makeAccount()
+        let reserve = try await makeAccount()
+        let freeze = try await makeAccount()
+        let clawback = try await makeAccount()
 
         let assetParams = AssetParams(
             total: 10_000_000,
@@ -49,8 +49,8 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.assetParams.assetName, "Full Asset")
     }
 
-    func test_assetCreate_nftParams() throws {
-        let creator = try makeAccount()
+    func test_assetCreate_nftParams() async throws {
+        let creator = try await makeAccount()
 
         let assetParams = AssetParams(
             total: 1,
@@ -75,8 +75,8 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.assetParams.decimals, 0)
     }
 
-    func test_assetCreate_withMetadataHash() throws {
-        let creator = try makeAccount()
+    func test_assetCreate_withMetadataHash() async throws {
+        let creator = try await makeAccount()
         let metadataHash = Data(repeating: 0xAB, count: 32)
 
         let assetParams = AssetParams(
@@ -101,8 +101,8 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.assetParams.metadataHash, metadataHash)
     }
 
-    func test_assetCreate_canBeSigned() throws {
-        let creator = try makeAccount()
+    func test_assetCreate_canBeSigned() async throws {
+        let creator = try await makeAccount()
 
         let assetParams = AssetParams(
             total: 1000,
@@ -128,8 +128,8 @@ final class AssetTransactionTests: XCTestCase {
 
     // MARK: - Asset Opt-In Transaction
 
-    func test_assetOptIn_setsCorrectFields() throws {
-        let account = try makeAccount()
+    func test_assetOptIn_setsCorrectFields() async throws {
+        let account = try await makeAccount()
 
         let tx = AssetOptInTransaction(
             sender: account.address,
@@ -144,8 +144,8 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.assetID, 99999)
     }
 
-    func test_assetOptIn_canBeSigned() throws {
-        let account = try makeAccount()
+    func test_assetOptIn_canBeSigned() async throws {
+        let account = try await makeAccount()
 
         let tx = AssetOptInTransaction(
             sender: account.address,
@@ -162,9 +162,9 @@ final class AssetTransactionTests: XCTestCase {
 
     // MARK: - Asset Transfer Transaction
 
-    func test_assetTransfer_buildsCorrectly() throws {
-        let sender = try makeAccount()
-        let receiver = try makeAccount()
+    func test_assetTransfer_buildsCorrectly() async throws {
+        let sender = try await makeAccount()
+        let receiver = try await makeAccount()
 
         let tx = AssetTransferTransaction(
             sender: sender.address,
@@ -183,10 +183,10 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.amount, 500)
     }
 
-    func test_assetTransfer_withCloseRemainder() throws {
-        let sender = try makeAccount()
-        let receiver = try makeAccount()
-        let closeTarget = try makeAccount()
+    func test_assetTransfer_withCloseRemainder() async throws {
+        let sender = try await makeAccount()
+        let receiver = try await makeAccount()
+        let closeTarget = try await makeAccount()
 
         let tx = AssetTransferTransaction(
             sender: sender.address,
@@ -204,9 +204,9 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.closeRemainderTo, closeTarget.address)
     }
 
-    func test_assetTransfer_zeroAmount() throws {
-        let sender = try makeAccount()
-        let receiver = try makeAccount()
+    func test_assetTransfer_zeroAmount() async throws {
+        let sender = try await makeAccount()
+        let receiver = try await makeAccount()
 
         let tx = AssetTransferTransaction(
             sender: sender.address,
@@ -222,9 +222,9 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.amount, 0)
     }
 
-    func test_assetTransfer_largeAmount() throws {
-        let sender = try makeAccount()
-        let receiver = try makeAccount()
+    func test_assetTransfer_largeAmount() async throws {
+        let sender = try await makeAccount()
+        let receiver = try await makeAccount()
 
         let tx = AssetTransferTransaction(
             sender: sender.address,
@@ -240,9 +240,9 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.amount, UInt64.max)
     }
 
-    func test_assetTransfer_canBeSigned() throws {
-        let sender = try makeAccount()
-        let receiver = try makeAccount()
+    func test_assetTransfer_canBeSigned() async throws {
+        let sender = try await makeAccount()
+        let receiver = try await makeAccount()
 
         let tx = AssetTransferTransaction(
             sender: sender.address,
@@ -261,9 +261,9 @@ final class AssetTransactionTests: XCTestCase {
 
     // MARK: - Asset Freeze Transaction
 
-    func test_assetFreeze_freezeAccount() throws {
-        let freezeAuthority = try makeAccount()
-        let target = try makeAccount()
+    func test_assetFreeze_freezeAccount() async throws {
+        let freezeAuthority = try await makeAccount()
+        let target = try await makeAccount()
 
         let tx = AssetFreezeTransaction(
             sender: freezeAuthority.address,
@@ -282,9 +282,9 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertTrue(tx.frozen)
     }
 
-    func test_assetFreeze_unfreezeAccount() throws {
-        let freezeAuthority = try makeAccount()
-        let target = try makeAccount()
+    func test_assetFreeze_unfreezeAccount() async throws {
+        let freezeAuthority = try await makeAccount()
+        let target = try await makeAccount()
 
         let tx = AssetFreezeTransaction(
             sender: freezeAuthority.address,
@@ -300,9 +300,9 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertFalse(tx.frozen)
     }
 
-    func test_assetFreeze_canBeSigned() throws {
-        let freezeAuthority = try makeAccount()
-        let target = try makeAccount()
+    func test_assetFreeze_canBeSigned() async throws {
+        let freezeAuthority = try await makeAccount()
+        let target = try await makeAccount()
 
         let tx = AssetFreezeTransaction(
             sender: freezeAuthority.address,
@@ -321,9 +321,9 @@ final class AssetTransactionTests: XCTestCase {
 
     // MARK: - Asset Config Transaction
 
-    func test_assetConfig_update() throws {
-        let manager = try makeAccount()
-        let newManager = try makeAccount()
+    func test_assetConfig_update() async throws {
+        let manager = try await makeAccount()
+        let newManager = try await makeAccount()
 
         let tx = AssetConfigTransaction.update(
             sender: manager.address,
@@ -339,8 +339,8 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.assetID, 12345)
     }
 
-    func test_assetConfig_destroy() throws {
-        let manager = try makeAccount()
+    func test_assetConfig_destroy() async throws {
+        let manager = try await makeAccount()
 
         let tx = AssetConfigTransaction.destroy(
             sender: manager.address,
@@ -355,8 +355,8 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.assetID, 12345)
     }
 
-    func test_assetConfig_canBeSigned() throws {
-        let manager = try makeAccount()
+    func test_assetConfig_canBeSigned() async throws {
+        let manager = try await makeAccount()
 
         let tx = AssetConfigTransaction.update(
             sender: manager.address,
@@ -373,10 +373,10 @@ final class AssetTransactionTests: XCTestCase {
 
     // MARK: - Asset Clawback Transaction
 
-    func test_assetClawback_buildsCorrectly() throws {
-        let clawbackAuth = try makeAccount()
-        let target = try makeAccount()
-        let destination = try makeAccount()
+    func test_assetClawback_buildsCorrectly() async throws {
+        let clawbackAuth = try await makeAccount()
+        let target = try await makeAccount()
+        let destination = try await makeAccount()
 
         let tx = AssetClawbackTransaction(
             sender: clawbackAuth.address,
@@ -397,10 +397,10 @@ final class AssetTransactionTests: XCTestCase {
         XCTAssertEqual(tx.amount, 500)
     }
 
-    func test_assetClawback_canBeSigned() throws {
-        let clawbackAuth = try makeAccount()
-        let target = try makeAccount()
-        let destination = try makeAccount()
+    func test_assetClawback_canBeSigned() async throws {
+        let clawbackAuth = try await makeAccount()
+        let target = try await makeAccount()
+        let destination = try await makeAccount()
 
         let tx = AssetClawbackTransaction(
             sender: clawbackAuth.address,

--- a/Tests/AlgoKitTests/AtomicComposerTests.swift
+++ b/Tests/AlgoKitTests/AtomicComposerTests.swift
@@ -1,0 +1,398 @@
+import XCTest
+@testable import AlgoKit
+import Algorand
+
+final class AtomicComposerTests: XCTestCase {
+
+    private let genesisID = "testnet-v1.0"
+    private let genesisHash = Data(repeating: 0, count: 32)
+
+    private func makeAccount() throws -> Account {
+        let algokit = AlgoKit(network: .testnet)
+        return try algokit.generateAccount()
+    }
+
+    // MARK: - AtomicTransactionComposer Builder
+
+    func test_composer_addCustomTransaction() async throws {
+        let algokit = AlgoKit(network: .testnet)
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(1),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let composer = await algokit.atomic()
+        let returned = await composer.add(tx)
+        XCTAssertNotNil(returned)
+    }
+
+    func test_composer_addMultipleCustomTransactions() async throws {
+        let algokit = AlgoKit(network: .testnet)
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx1 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(1),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx2 = PaymentTransaction(
+            sender: bob.address,
+            receiver: alice.address,
+            amount: .algos(2),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let composer = await algokit.atomic()
+        let _ = await composer.add(tx1)
+        let result = await composer.add(tx2)
+        XCTAssertNotNil(result)
+    }
+
+    func test_composer_buildWithCustomTransactions() async throws {
+        let algokit = AlgoKit(network: .testnet)
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx1 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(5),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx2 = PaymentTransaction(
+            sender: bob.address,
+            receiver: alice.address,
+            amount: .algos(3),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let composer = await algokit.atomic()
+        let _ = await composer.add(tx1)
+        let _ = await composer.add(tx2)
+        let result = try await composer.build()
+        XCTAssertNotNil(result)
+    }
+
+    func test_composer_buildSingleTransaction() async throws {
+        let algokit = AlgoKit(network: .testnet)
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(1),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let composer = await algokit.atomic()
+        let _ = await composer.add(tx)
+        let result = try await composer.build()
+        XCTAssertNotNil(result)
+    }
+
+    func test_composer_addMixedTransactionTypes() async throws {
+        let algokit = AlgoKit(network: .testnet)
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let payTx = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(1),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let assetTx = AssetOptInTransaction(
+            sender: bob.address,
+            assetID: 12345,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let composer = await algokit.atomic()
+        let _ = await composer.add(payTx)
+        let _ = await composer.add(assetTx)
+        let result = try await composer.build()
+        XCTAssertNotNil(result)
+    }
+
+    // MARK: - AtomicTransactionResult Signing
+
+    func test_result_signedByArray() async throws {
+        let algokit = AlgoKit(network: .testnet)
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx1 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(5),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx2 = PaymentTransaction(
+            sender: bob.address,
+            receiver: alice.address,
+            amount: .algos(3),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let composer = await algokit.atomic()
+        let _ = await composer.add(tx1)
+        let _ = await composer.add(tx2)
+        let result = try await composer.build()
+
+        let signed = try await result.signedBy([alice, bob])
+        XCTAssertNotNil(signed)
+    }
+
+    func test_result_signedByDictionary() async throws {
+        let algokit = AlgoKit(network: .testnet)
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx1 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(5),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx2 = PaymentTransaction(
+            sender: bob.address,
+            receiver: alice.address,
+            amount: .algos(3),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let composer = await algokit.atomic()
+        let _ = await composer.add(tx1)
+        let _ = await composer.add(tx2)
+        let result = try await composer.build()
+
+        let signed = try await result.signedBy([0: alice, 1: bob])
+        XCTAssertNotNil(signed)
+    }
+
+    func test_result_signedByArrayMismatchThrows() async throws {
+        let algokit = AlgoKit(network: .testnet)
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx1 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(5),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx2 = PaymentTransaction(
+            sender: bob.address,
+            receiver: alice.address,
+            amount: .algos(3),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let composer = await algokit.atomic()
+        let _ = await composer.add(tx1)
+        let _ = await composer.add(tx2)
+        let result = try await composer.build()
+
+        // Only provide 1 signer for 2 transactions
+        do {
+            _ = try await result.signedBy([alice])
+            XCTFail("Expected error for mismatched signer count")
+        } catch {
+            // Expected: Number of signers must match number of transactions
+        }
+    }
+
+    // MARK: - AtomicTransactionGroup
+
+    func test_group_multipleTransactionsHaveGroupID() throws {
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx1 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(1),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx2 = PaymentTransaction(
+            sender: bob.address,
+            receiver: alice.address,
+            amount: .algos(2),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx3 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(3),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let group = try AtomicTransactionGroup(transactions: [tx1, tx2, tx3])
+        XCTAssertEqual(group.transactions.count, 3)
+        XCTAssertNotNil(group.groupID)
+    }
+
+    func test_group_differentTransactionsProduceDifferentGroupIDs() throws {
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx1 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(1),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx2 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(2),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let group1 = try AtomicTransactionGroup(transactions: [tx1])
+        let group2 = try AtomicTransactionGroup(transactions: [tx2])
+
+        XCTAssertNotEqual(group1.groupID, group2.groupID)
+    }
+
+    func test_group_signWithPartialSigners() throws {
+        let alice = try makeAccount()
+        let bob = try makeAccount()
+
+        let tx1 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(5),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx2 = PaymentTransaction(
+            sender: bob.address,
+            receiver: alice.address,
+            amount: .algos(3),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let group = try AtomicTransactionGroup(transactions: [tx1, tx2])
+
+        // Sign only first transaction
+        let signedGroup = try SignedAtomicTransactionGroup.sign(group, with: [0: alice])
+        XCTAssertNotNil(signedGroup)
+    }
+
+    // MARK: - Transaction Group Validation
+
+    func test_submitGroup_mismatchThrows() async {
+        let algokit = AlgoKit(network: .testnet)
+        let alice = try! makeAccount()
+        let bob = try! makeAccount()
+
+        let tx1 = PaymentTransaction(
+            sender: alice.address,
+            receiver: bob.address,
+            amount: .algos(5),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        let tx2 = PaymentTransaction(
+            sender: bob.address,
+            receiver: alice.address,
+            amount: .algos(3),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: genesisID,
+            genesisHash: genesisHash
+        )
+
+        // 2 transactions but only 1 signer
+        do {
+            _ = try await algokit.submitGroup([tx1, tx2], signedBy: [alice])
+            XCTFail("Expected error for mismatched counts")
+        } catch {
+            // Expected: Number of transactions must match number of signers
+        }
+    }
+}

--- a/Tests/AlgoKitTests/AtomicComposerTests.swift
+++ b/Tests/AlgoKitTests/AtomicComposerTests.swift
@@ -329,7 +329,7 @@ final class AtomicComposerTests: XCTestCase {
         XCTAssertNotEqual(group1.groupID, group2.groupID)
     }
 
-    func test_group_signWithPartialSigners() async throws {
+    func test_group_signWithPartialSigners_throws() async throws {
         let alice = try await makeAccount()
         let bob = try await makeAccount()
 
@@ -355,9 +355,13 @@ final class AtomicComposerTests: XCTestCase {
 
         let group = try AtomicTransactionGroup(transactions: [tx1, tx2])
 
-        // Sign only first transaction
-        let signedGroup = try SignedAtomicTransactionGroup.sign(group, with: [0: alice])
-        XCTAssertNotNil(signedGroup)
+        // Partial signing (missing signer for index 1) should throw
+        do {
+            _ = try SignedAtomicTransactionGroup.sign(group, with: [0: alice])
+            XCTFail("Expected error for missing signer")
+        } catch {
+            // Expected: No account provided for transaction at index 1
+        }
     }
 
     // MARK: - Transaction Group Validation

--- a/Tests/AlgoKitTests/AtomicComposerTests.swift
+++ b/Tests/AlgoKitTests/AtomicComposerTests.swift
@@ -7,17 +7,17 @@ final class AtomicComposerTests: XCTestCase {
     private let genesisID = "testnet-v1.0"
     private let genesisHash = Data(repeating: 0, count: 32)
 
-    private func makeAccount() throws -> Account {
+    private func makeAccount() async throws -> Account {
         let algokit = AlgoKit(network: .testnet)
-        return try algokit.generateAccount()
+        return try await algokit.generateAccount()
     }
 
     // MARK: - AtomicTransactionComposer Builder
 
     func test_composer_addCustomTransaction() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx = PaymentTransaction(
             sender: alice.address,
@@ -36,8 +36,8 @@ final class AtomicComposerTests: XCTestCase {
 
     func test_composer_addMultipleCustomTransactions() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx1 = PaymentTransaction(
             sender: alice.address,
@@ -67,8 +67,8 @@ final class AtomicComposerTests: XCTestCase {
 
     func test_composer_buildWithCustomTransactions() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx1 = PaymentTransaction(
             sender: alice.address,
@@ -99,8 +99,8 @@ final class AtomicComposerTests: XCTestCase {
 
     func test_composer_buildSingleTransaction() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx = PaymentTransaction(
             sender: alice.address,
@@ -120,8 +120,8 @@ final class AtomicComposerTests: XCTestCase {
 
     func test_composer_addMixedTransactionTypes() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let payTx = PaymentTransaction(
             sender: alice.address,
@@ -153,8 +153,8 @@ final class AtomicComposerTests: XCTestCase {
 
     func test_result_signedByArray() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx1 = PaymentTransaction(
             sender: alice.address,
@@ -187,8 +187,8 @@ final class AtomicComposerTests: XCTestCase {
 
     func test_result_signedByDictionary() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx1 = PaymentTransaction(
             sender: alice.address,
@@ -221,8 +221,8 @@ final class AtomicComposerTests: XCTestCase {
 
     func test_result_signedByArrayMismatchThrows() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx1 = PaymentTransaction(
             sender: alice.address,
@@ -260,9 +260,9 @@ final class AtomicComposerTests: XCTestCase {
 
     // MARK: - AtomicTransactionGroup
 
-    func test_group_multipleTransactionsHaveGroupID() throws {
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+    func test_group_multipleTransactionsHaveGroupID() async throws {
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx1 = PaymentTransaction(
             sender: alice.address,
@@ -299,9 +299,9 @@ final class AtomicComposerTests: XCTestCase {
         XCTAssertNotNil(group.groupID)
     }
 
-    func test_group_differentTransactionsProduceDifferentGroupIDs() throws {
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+    func test_group_differentTransactionsProduceDifferentGroupIDs() async throws {
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx1 = PaymentTransaction(
             sender: alice.address,
@@ -329,9 +329,9 @@ final class AtomicComposerTests: XCTestCase {
         XCTAssertNotEqual(group1.groupID, group2.groupID)
     }
 
-    func test_group_signWithPartialSigners() throws {
-        let alice = try makeAccount()
-        let bob = try makeAccount()
+    func test_group_signWithPartialSigners() async throws {
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx1 = PaymentTransaction(
             sender: alice.address,
@@ -362,10 +362,10 @@ final class AtomicComposerTests: XCTestCase {
 
     // MARK: - Transaction Group Validation
 
-    func test_submitGroup_mismatchThrows() async {
+    func test_submitGroup_mismatchThrows() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let alice = try! makeAccount()
-        let bob = try! makeAccount()
+        let alice = try await makeAccount()
+        let bob = try await makeAccount()
 
         let tx1 = PaymentTransaction(
             sender: alice.address,

--- a/Tests/AlgoKitTests/IndexerAndNetworkTests.swift
+++ b/Tests/AlgoKitTests/IndexerAndNetworkTests.swift
@@ -1,0 +1,316 @@
+import XCTest
+@testable import AlgoKit
+import Algorand
+
+final class IndexerAndNetworkTests: XCTestCase {
+
+    // MARK: - Indexer Guard Clause Tests
+
+    func test_searchTransactions_throwsWithoutIndexer() async {
+        let config = AlgorandConfiguration.custom(
+            algodURL: URL(string: "https://node.example.com")!,
+            indexerURL: nil,
+            apiToken: "test"
+        )
+        let algokit = AlgoKit(configuration: config)
+
+        do {
+            _ = try await algokit.searchTransactions()
+            XCTFail("Expected error when indexer is not configured")
+        } catch {
+            // Expected: Indexer client not configured
+        }
+    }
+
+    func test_searchAssets_throwsWithoutIndexer() async {
+        let config = AlgorandConfiguration.custom(
+            algodURL: URL(string: "https://node.example.com")!,
+            indexerURL: nil,
+            apiToken: "test"
+        )
+        let algokit = AlgoKit(configuration: config)
+
+        do {
+            _ = try await algokit.searchAssets()
+            XCTFail("Expected error when indexer is not configured")
+        } catch {
+            // Expected: Indexer client not configured
+        }
+    }
+
+    func test_getAsset_throwsWithoutIndexer() async {
+        let config = AlgorandConfiguration.custom(
+            algodURL: URL(string: "https://node.example.com")!,
+            indexerURL: nil,
+            apiToken: "test"
+        )
+        let algokit = AlgoKit(configuration: config)
+
+        do {
+            _ = try await algokit.getAsset(12345)
+            XCTFail("Expected error when indexer is not configured")
+        } catch {
+            // Expected: Indexer client not configured
+        }
+    }
+
+    func test_getApplication_throwsWithoutIndexer() async {
+        let config = AlgorandConfiguration.custom(
+            algodURL: URL(string: "https://node.example.com")!,
+            indexerURL: nil,
+            apiToken: "test"
+        )
+        let algokit = AlgoKit(configuration: config)
+
+        do {
+            _ = try await algokit.getApplication(12345)
+            XCTFail("Expected error when indexer is not configured")
+        } catch {
+            // Expected: Indexer client not configured
+        }
+    }
+
+    // MARK: - Network Configuration Tests
+
+    func test_customConfig_withoutIndexer() async {
+        let config = AlgorandConfiguration.custom(
+            algodURL: URL(string: "https://node.example.com")!,
+            indexerURL: nil,
+            apiToken: "test"
+        )
+        let algokit = AlgoKit(configuration: config)
+
+        let indexer = await algokit.indexerClient
+        XCTAssertNil(indexer)
+    }
+
+    func test_customConfig_withIndexer() async {
+        let config = AlgorandConfiguration.custom(
+            algodURL: URL(string: "https://node.example.com")!,
+            indexerURL: URL(string: "https://indexer.example.com")!,
+            apiToken: "test"
+        )
+        let algokit = AlgoKit(configuration: config)
+
+        let indexer = await algokit.indexerClient
+        XCTAssertNotNil(indexer)
+    }
+
+    func test_testnet_hasIndexer() async {
+        let algokit = AlgoKit(network: .testnet)
+        let indexer = await algokit.indexerClient
+        XCTAssertNotNil(indexer)
+    }
+
+    func test_mainnet_hasIndexer() async {
+        let algokit = AlgoKit(network: .mainnet)
+        let indexer = await algokit.indexerClient
+        XCTAssertNotNil(indexer)
+    }
+
+    func test_localnet_hasIndexer() async {
+        let algokit = AlgoKit(network: .localnet)
+        let indexer = await algokit.indexerClient
+        XCTAssertNotNil(indexer)
+    }
+
+    // MARK: - Configuration URL Tests
+
+    func test_customConfig_preservesURL() async {
+        let url = URL(string: "https://my-custom-node.example.com")!
+        let config = AlgorandConfiguration.custom(
+            algodURL: url,
+            indexerURL: nil,
+            apiToken: "my-token"
+        )
+        let algokit = AlgoKit(configuration: config)
+
+        let storedConfig = await algokit.configuration
+        XCTAssertEqual(storedConfig.algodURL, url)
+    }
+
+    func test_customNetworkInit_works() {
+        let algodURL = URL(string: "https://custom-algod.example.com")!
+        let indexerURL = URL(string: "https://custom-indexer.example.com")!
+        let algokit = AlgoKit(network: .custom(algodURL: algodURL, indexerURL: indexerURL))
+        XCTAssertNotNil(algokit)
+    }
+
+    // MARK: - Key Registration Transaction Tests (Extended)
+
+    func test_keyRegistration_onlineWithStateProofKey() throws {
+        let algokit = AlgoKit(network: .testnet)
+        let account = try algokit.generateAccount()
+
+        let voteKey = Data(repeating: 1, count: 32)
+        let selectionKey = Data(repeating: 2, count: 32)
+        let stateProofKey = Data(repeating: 3, count: 64)
+
+        let tx = KeyRegistrationTransaction.online(
+            sender: account.address,
+            votePK: voteKey,
+            selectionPK: selectionKey,
+            voteFirst: 1000,
+            voteLast: 3_000_000,
+            voteKeyDilution: 10000,
+            stateProofPK: stateProofKey,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: "testnet-v1.0",
+            genesisHash: Data(repeating: 0, count: 32)
+        )
+
+        XCTAssertEqual(tx.sender, account.address)
+        XCTAssertEqual(tx.voteFirst, 1000)
+        XCTAssertEqual(tx.voteLast, 3_000_000)
+        XCTAssertEqual(tx.voteKeyDilution, 10000)
+    }
+
+    func test_keyRegistration_onlineCanBeSigned() throws {
+        let algokit = AlgoKit(network: .testnet)
+        let account = try algokit.generateAccount()
+
+        let tx = KeyRegistrationTransaction.online(
+            sender: account.address,
+            votePK: Data(repeating: 1, count: 32),
+            selectionPK: Data(repeating: 2, count: 32),
+            voteFirst: 1000,
+            voteLast: 2_000_000,
+            voteKeyDilution: 10000,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: "testnet-v1.0",
+            genesisHash: Data(repeating: 0, count: 32)
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: account)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    func test_keyRegistration_offlineCanBeSigned() throws {
+        let algokit = AlgoKit(network: .testnet)
+        let account = try algokit.generateAccount()
+
+        let tx = KeyRegistrationTransaction.offline(
+            sender: account.address,
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: "testnet-v1.0",
+            genesisHash: Data(repeating: 0, count: 32)
+        )
+
+        let signed = try SignedTransaction.sign(tx, with: account)
+        XCTAssertFalse(signed.signature.isEmpty)
+    }
+
+    // MARK: - Payment Transaction Tests (Extended)
+
+    func test_paymentTransaction_selfTransfer() throws {
+        let algokit = AlgoKit(network: .testnet)
+        let account = try algokit.generateAccount()
+
+        let tx = PaymentTransaction(
+            sender: account.address,
+            receiver: account.address,
+            amount: .algos(0),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: "testnet-v1.0",
+            genesisHash: Data(repeating: 0, count: 32)
+        )
+
+        XCTAssertEqual(tx.sender, tx.receiver)
+        XCTAssertEqual(tx.amount.value, 0)
+    }
+
+    func test_paymentTransaction_withEmptyNote() throws {
+        let algokit = AlgoKit(network: .testnet)
+        let sender = try algokit.generateAccount()
+        let receiver = try algokit.generateAccount()
+
+        let tx = PaymentTransaction(
+            sender: sender.address,
+            receiver: receiver.address,
+            amount: .algos(1),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: "testnet-v1.0",
+            genesisHash: Data(repeating: 0, count: 32),
+            note: Data()
+        )
+
+        XCTAssertEqual(tx.note, Data())
+    }
+
+    func test_paymentTransaction_withLargeNote() throws {
+        let algokit = AlgoKit(network: .testnet)
+        let sender = try algokit.generateAccount()
+        let receiver = try algokit.generateAccount()
+        let noteData = Data(repeating: 0x42, count: 1000)
+
+        let tx = PaymentTransaction(
+            sender: sender.address,
+            receiver: receiver.address,
+            amount: .algos(1),
+            firstValid: 1000,
+            lastValid: 2000,
+            genesisID: "testnet-v1.0",
+            genesisHash: Data(repeating: 0, count: 32),
+            note: noteData
+        )
+
+        XCTAssertEqual(tx.note?.count, 1000)
+    }
+
+    // MARK: - MicroAlgos Extended Tests
+
+    func test_microAlgos_precisionBoundary() {
+        // Smallest non-zero amount
+        let oneMicro = MicroAlgos.microAlgos(1)
+        XCTAssertEqual(oneMicro.algos, 0.000001)
+
+        // Verify round-trip
+        let fromAlgos = MicroAlgos.algos(0.000001)
+        XCTAssertEqual(fromAlgos.value, 1)
+    }
+
+    func test_microAlgos_multipleConversions() {
+        let amounts: [(Double, UInt64)] = [
+            (0.1, 100_000),
+            (0.01, 10_000),
+            (0.001, 1_000),
+            (1.5, 1_500_000),
+            (100.0, 100_000_000),
+            (999.999999, 999_999_999),
+        ]
+
+        for (algos, expectedMicro) in amounts {
+            let micro = MicroAlgos.algos(algos)
+            XCTAssertEqual(micro.value, expectedMicro, "Failed for \(algos) ALGO")
+        }
+    }
+
+    // MARK: - Account Tests (Extended)
+
+    func test_account_multipleRecoveriesAreConsistent() throws {
+        let algokit = AlgoKit(network: .testnet)
+        let original = try algokit.generateAccount()
+        let mnemonic = try original.mnemonic()
+
+        let recovered1 = try algokit.account(from: mnemonic)
+        let recovered2 = try algokit.account(from: mnemonic)
+
+        XCTAssertEqual(recovered1.address, recovered2.address)
+        XCTAssertEqual(recovered1.publicKey, recovered2.publicKey)
+    }
+
+    func test_account_differentAccountsHaveDifferentKeys() throws {
+        let algokit = AlgoKit(network: .testnet)
+
+        let accounts = try (0..<5).map { _ in try algokit.generateAccount() }
+        let addresses = Set(accounts.map { $0.address.description })
+
+        // All 5 accounts should have unique addresses
+        XCTAssertEqual(addresses.count, 5)
+    }
+}

--- a/Tests/AlgoKitTests/IndexerAndNetworkTests.swift
+++ b/Tests/AlgoKitTests/IndexerAndNetworkTests.swift
@@ -138,9 +138,9 @@ final class IndexerAndNetworkTests: XCTestCase {
 
     // MARK: - Key Registration Transaction Tests (Extended)
 
-    func test_keyRegistration_onlineWithStateProofKey() throws {
+    func test_keyRegistration_onlineWithStateProofKey() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let account = try algokit.generateAccount()
+        let account = try await algokit.generateAccount()
 
         let voteKey = Data(repeating: 1, count: 32)
         let selectionKey = Data(repeating: 2, count: 32)
@@ -166,9 +166,9 @@ final class IndexerAndNetworkTests: XCTestCase {
         XCTAssertEqual(tx.voteKeyDilution, 10000)
     }
 
-    func test_keyRegistration_onlineCanBeSigned() throws {
+    func test_keyRegistration_onlineCanBeSigned() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let account = try algokit.generateAccount()
+        let account = try await algokit.generateAccount()
 
         let tx = KeyRegistrationTransaction.online(
             sender: account.address,
@@ -187,9 +187,9 @@ final class IndexerAndNetworkTests: XCTestCase {
         XCTAssertFalse(signed.signature.isEmpty)
     }
 
-    func test_keyRegistration_offlineCanBeSigned() throws {
+    func test_keyRegistration_offlineCanBeSigned() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let account = try algokit.generateAccount()
+        let account = try await algokit.generateAccount()
 
         let tx = KeyRegistrationTransaction.offline(
             sender: account.address,
@@ -205,9 +205,9 @@ final class IndexerAndNetworkTests: XCTestCase {
 
     // MARK: - Payment Transaction Tests (Extended)
 
-    func test_paymentTransaction_selfTransfer() throws {
+    func test_paymentTransaction_selfTransfer() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let account = try algokit.generateAccount()
+        let account = try await algokit.generateAccount()
 
         let tx = PaymentTransaction(
             sender: account.address,
@@ -223,10 +223,10 @@ final class IndexerAndNetworkTests: XCTestCase {
         XCTAssertEqual(tx.amount.value, 0)
     }
 
-    func test_paymentTransaction_withEmptyNote() throws {
+    func test_paymentTransaction_withEmptyNote() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let sender = try algokit.generateAccount()
-        let receiver = try algokit.generateAccount()
+        let sender = try await algokit.generateAccount()
+        let receiver = try await algokit.generateAccount()
 
         let tx = PaymentTransaction(
             sender: sender.address,
@@ -242,10 +242,10 @@ final class IndexerAndNetworkTests: XCTestCase {
         XCTAssertEqual(tx.note, Data())
     }
 
-    func test_paymentTransaction_withLargeNote() throws {
+    func test_paymentTransaction_withLargeNote() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let sender = try algokit.generateAccount()
-        let receiver = try algokit.generateAccount()
+        let sender = try await algokit.generateAccount()
+        let receiver = try await algokit.generateAccount()
         let noteData = Data(repeating: 0x42, count: 1000)
 
         let tx = PaymentTransaction(
@@ -292,22 +292,25 @@ final class IndexerAndNetworkTests: XCTestCase {
 
     // MARK: - Account Tests (Extended)
 
-    func test_account_multipleRecoveriesAreConsistent() throws {
+    func test_account_multipleRecoveriesAreConsistent() async throws {
         let algokit = AlgoKit(network: .testnet)
-        let original = try algokit.generateAccount()
+        let original = try await algokit.generateAccount()
         let mnemonic = try original.mnemonic()
 
-        let recovered1 = try algokit.account(from: mnemonic)
-        let recovered2 = try algokit.account(from: mnemonic)
+        let recovered1 = try await algokit.account(from: mnemonic)
+        let recovered2 = try await algokit.account(from: mnemonic)
 
         XCTAssertEqual(recovered1.address, recovered2.address)
         XCTAssertEqual(recovered1.publicKey, recovered2.publicKey)
     }
 
-    func test_account_differentAccountsHaveDifferentKeys() throws {
+    func test_account_differentAccountsHaveDifferentKeys() async throws {
         let algokit = AlgoKit(network: .testnet)
 
-        let accounts = try (0..<5).map { _ in try algokit.generateAccount() }
+        var accounts: [Account] = []
+        for _ in 0..<5 {
+            accounts.append(try await algokit.generateAccount())
+        }
         let addresses = Set(accounts.map { $0.address.description })
 
         // All 5 accounts should have unique addresses


### PR DESCRIPTION
## Summary
- Add **4 new test files** with ~75 new unit tests covering previously untested SDK areas
- **ApplicationTransactionTests**: all 6 app call types (create, call, optIn, closeOut, update, delete) with arguments, foreign references, and signing verification
- **AssetTransactionTests**: full asset lifecycle — create (NFT, metadata, full params), opt-in, transfer (zero/large/closeRemainder), freeze/unfreeze, config update/destroy, clawback
- **AtomicComposerTests**: builder pattern with custom/mixed transactions, signedBy array and dictionary paths, mismatch count validation, group ID uniqueness, submitGroup validation
- **IndexerAndNetworkTests**: all 4 indexer guard clauses, network config with/without indexer, key registration signing, payment edge cases, MicroAlgos precision boundaries, account consistency

Increases test count from **80 → ~155 tests**.

Closes #9

## Test plan
- [x] `swift build` passes locally
- [ ] CI (Ubuntu + macOS) builds and runs all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)