### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,12 @@ name: Documentation
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+    paths:
+      - "Sources/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -17,8 +22,9 @@ concurrency:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     - name: Build Documentation
@@ -40,6 +46,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 10
     steps:
     - name: Deploy to GitHub Pages
       id: deployment

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -2,13 +2,32 @@ name: macOS
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/macOS.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/macOS.yml"
+
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macOS:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Select Xcode
       run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
     - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,14 +2,34 @@ name: ubuntu
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/ubuntu.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "Sources/**"
+      - "Tests/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/ubuntu.yml"
+
+concurrency:
+  group: ubuntu-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ubuntu:
+    # GitHub-hosted Linux: deliberate Swift Linux compile via the official swift container.
     runs-on: ubuntu-latest
     container: swift:6.0
+    timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
Standardizes the GitHub Actions workflows for this Swift SPM library (PUBLIC repo, GitHub-hosted runners).

- **macOS.yml**: scoped trigger to `branches: [main]` with a swift-spm `paths:` set (`Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`, the workflow file); added a `pull_request` trigger; added `concurrency` group with `cancel-in-progress: true`; `actions/checkout@v5`; `timeout-minutes`.
- **ubuntu.yml**: same path/concurrency/PR treatment. Kept `ubuntu-latest` + `swift:6.0` container as a deliberate Linux compile (one-line comment added). `actions/checkout@v5`; `timeout-minutes`.
- **docs.yml** (GitHub Pages): added a site-source-scoped `paths:` set (`Sources/**`, `Package.swift`, `Package.resolved`, the workflow) to the push trigger; left `workflow_dispatch` untouched; kept the existing `pages` concurrency group; `actions/checkout@v5`; `timeout-minutes` on both jobs.
- Runners left GitHub-hosted (correct for a PUBLIC repo). No new ci.yml created: existing macOS + ubuntu workflows already provide real `swift build`/`swift test` coverage on both platforms.

Mirrors the CorvidLabs/merlin CI standard.