### PR TITLE
Update: pin Trust v1.1.1 and SpecSync 5.1.1

### DIFF
--- a/.github/workflows/trust.yml
+++ b/.github/workflows/trust.yml
@@ -28,13 +28,13 @@ jobs:
         run: echo "range=${{ github.event.pull_request.base.sha || github.event.before }}..${{ github.event.pull_request.head.sha || github.sha }}" >> "$GITHUB_OUTPUT"
       - name: CorvidLabs Trust gate
         id: trust
-        uses: CorvidLabs/trust@9d32b5786d2e9e4d39fc581c0091c721ee3d4226 # v1.0.0
+        uses: CorvidLabs/trust@a239f78658e5ad0f12fa230f494890e40c6e4d7b # v1.1.1
         with:
           range: ${{ steps.comparison.outputs.range }}
       - name: Enforce the verified SpecSync lifecycle
-        uses: CorvidLabs/spec-sync@59bbfa766c6cce01ab815ab47db195b0629cc014 # v5.0.1
+        uses: CorvidLabs/spec-sync@a89d827e93fa0bc9e6168447e66a0ad30fa92e65 # v5.1.1
         with:
-          version: 5.0.1
+          version: "5.1.1"
           strict: true
           require-coverage: 100
           lifecycle-enforce: true

--- a/.specsync/changes/CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit/approvals.json
+++ b/.specsync/changes/CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit/approvals.json
@@ -41,6 +41,13 @@
       "timestamp": 1783986676,
       "digest": "057e0efac725049ea1ac4b3513404920576a80b8c563f66b915193f309c5759d",
       "note": "Fresh closing approval after the audited CHG3 delivery-input change and supported native verification; all prior approvals and reopen history remain preserved."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784415754,
+      "digest": "197771e76e7dfea7a93ea59230cc1d1bcbc87cabd23c884ca240074ce0628d98",
+      "note": "Re-acceptance with the Trust 1.1.1 and SpecSync 5.1.1 pins; canonical deltas were already integrated and were not replayed."
     }
   ],
   "reopenings": [
@@ -145,6 +152,40 @@
       },
       "stale_acceptance_input_digest": "d2a3feaff1e9a71b51603848393ffa50a96ce379e7d79ce13809a0ced0551743",
       "current_acceptance_input_digest": "a3f29faf7e668dd18c51c6d1e2b60c7fbdd4cffa2ddb60cb61e9c6768583a0f9"
+    },
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit",
+      "actor": "user:0xLeif",
+      "reason": "Trust 1.1.1 and SpecSync 5.1.1 pins changed governed delivery inputs; accepted verification is stale.",
+      "timestamp": 1784415621,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "user:0xLeif",
+        "timestamp": 1783986676,
+        "digest": "057e0efac725049ea1ac4b3513404920576a80b8c563f66b915193f309c5759d",
+        "note": "Fresh closing approval after the audited CHG3 delivery-input change and supported native verification; all prior approvals and reopen history remain preserved."
+      },
+      "prior_verification": {
+        "timestamp": 1783986671,
+        "commit": "ed08f33e5df68d3cc5065f4501bc7126e47d0a36",
+        "contract_digest": "941dc3121d94da676c1743bce1814f958235c8978093f662be6421950a560378",
+        "workspace_digest": "fb540cb7bc51c79199a4d725ac2d53c55f24166bcc0f6e557fae4cd4903ae0ce",
+        "acceptance_input_digest": "a3f29faf7e668dd18c51c6d1e2b60c7fbdd4cffa2ddb60cb61e9c6768583a0f9",
+        "passed": true,
+        "commands": [
+          {
+            "command": "fledge lanes run verify",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": []
+      },
+      "stale_acceptance_input_digest": "a3f29faf7e668dd18c51c6d1e2b60c7fbdd4cffa2ddb60cb61e9c6768583a0f9",
+      "current_acceptance_input_digest": "039f741169e79e412ccfcf0434152b8cc8249c61c37ebdda38d0d0714d04d127"
     }
   ]
 }

--- a/.specsync/changes/CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit/state.json
+++ b/.specsync/changes/CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit/state.json
@@ -9,7 +9,7 @@
   "canonical_applied": true,
   "base_commit": "39a7059eb1010bbfe9894871c58441bdd2f4a47b",
   "created_at": 1783884714,
-  "updated_at": 1783986676,
+  "updated_at": 1784415754,
   "affected_specs": [],
   "affected_paths": [
     ".github/",

--- a/.specsync/changes/CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit/verification-attempts.json
+++ b/.specsync/changes/CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit/verification-attempts.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784415714,
+      "commit": "cf2ded7b3ae9f43f967a9dc19cd8b9b51ec7c1f4",
+      "contract_digest": "941dc3121d94da676c1743bce1814f958235c8978093f662be6421950a560378",
+      "workspace_digest": "5a5d84ec329ffc7c719f186cde2a0fdca0e5025e4f11bd2f7c77e943ce9195d4",
+      "passed": true,
+      "commands": [
+        {
+          "command": "fledge lanes run verify",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": []
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit/verification.json
+++ b/.specsync/changes/CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit/verification.json
@@ -1,9 +1,164 @@
 {
-  "timestamp": 1783986671,
-  "commit": "ed08f33e5df68d3cc5065f4501bc7126e47d0a36",
+  "timestamp": 1784415714,
+  "commit": "cf2ded7b3ae9f43f967a9dc19cd8b9b51ec7c1f4",
   "contract_digest": "941dc3121d94da676c1743bce1814f958235c8978093f662be6421950a560378",
-  "workspace_digest": "fb540cb7bc51c79199a4d725ac2d53c55f24166bcc0f6e557fae4cd4903ae0ce",
-  "acceptance_input_digest": "a3f29faf7e668dd18c51c6d1e2b60c7fbdd4cffa2ddb60cb61e9c6768583a0f9",
+  "workspace_digest": "5a5d84ec329ffc7c719f186cde2a0fdca0e5025e4f11bd2f7c77e943ce9195d4",
+  "acceptance_input_digest": "3c8b2f9ecfac28055a82fb5e99ec31ea9cbaea6a3221ec30cb1ad4b8bed93ae9",
+  "acceptance_manifest": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "path": ".attest.json",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "2581fe52873327db0bbac357a5102a0dbb18a1eea5a690b7b75eaa571e50cf65",
+        "entry_digest": "2904a18e18582f191a1d359d16e7bc61a7596ac77f62e55a94de56b3da8c796e",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".augur.toml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "17f6ad5b84b4db012f0e3f398a96a478c1324fd47e72e1dd2a13c7cf9a432983",
+        "entry_digest": "bac13c952da05292bdd0af5849aad9d9def3ae5afc830fa42b6914b2fd874beb",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".github/workflows/docs.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "3ca6f1d83fddb1d1296074145ad5d69c31ef53af1fc4a77401e49fc0d74daf11",
+        "entry_digest": "7b9776d8dacfff1e31129a15fe41217ad537652a9b85d01c7241e7e1a2c3be3c",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".github/workflows/macOS.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "b3874a5f87c31f99c83a9b5441a8f018dcd448ec7ee81593395a23312f2b0c35",
+        "entry_digest": "0f0e333601ff95c8300df1f476897733730e6b41e7ec4975f3a26f292f1c47e1",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".github/workflows/trust.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "b04cdee06d69a77377bb39a6ded1a944cf416f431b1feca2692eeed244e42813",
+        "entry_digest": "d8d38bfe82f88f14c72c0203d166be8b3f2f55ab9d50127f4ddee88f6e3a4df5",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".github/workflows/ubuntu.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "64841487c627dab97e335ba865f7bc5047a3f2a3d29a2c3c465a4204ea5b997f",
+        "entry_digest": "c7bda18b9b0a228895273ea1d507ccf842381cc0adcabd1feea4954b5952176e",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".specsync/.gitignore",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "a505253bd2fdfb84f8121e89e48bbc67144082b5a88f439ee6acfb45424799b0",
+        "entry_digest": "ec3b8bd021ac6ac36ddfba3d0d6b84535be8074b917e9bffa050216e422d1792",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".specsync/adoption-report.json",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "6a6f15eda65f5a68d1282f7177cb12167ce248f023ecbadf826db09656f915d3",
+        "entry_digest": "571e12e5b90654f4efc47b67b1ba7d75fe40146d047207b0162bf851969f02fd",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".specsync/config.toml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "73de5bc8fdc419a5cd499845e040e3ec687f0ed7eb1dcbaa0777e0caf204e883",
+        "entry_digest": "5ebdc88fc9417e9faf562ad7da3c042f99e8b2808cdf50d99790df44abdfa02f",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".specsync/registry.toml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "dfdbb832850219a98a424e22df244b984eff1a21528be305c25f7cdc8c14c273",
+        "entry_digest": "4481a40cb9bb464608fc71ffebe7a73e97462e24903db1076a669e8970b8053e",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".specsync/sdd.json",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "c92cbe18fbf227e4ae4d17ed96a35d646419813442aa39976cb279d3753143fd",
+        "entry_digest": "745759f40a076630bc7257f60d15b9071e986e91fbb5a1b018f191386019720b",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".specsync/version",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "23b6867924dfeb9cf532753438dc919669bf93ad88215e11c15630a4acbf4299",
+        "entry_digest": "339b5f88be30302336707baa5dab61fd4b324d04e495d3bb772cf893fb4f73bc",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".trust.toml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "0ca37f8dc00590f9fa1acbbbc0819dd4c39d7968a49fe784b8180520a856a4de",
+        "entry_digest": "c97d671502e9908684fe170ba284831dac9caa819ed1d567b776187ec17fa77f",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "AGENTS.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "d2561f21b1519604865b1ae0c4a6586f5f2bea591c9b3b7d8c4ae0f274b73df5",
+        "entry_digest": "616b86acb3d91a5f9880826f4063978e95d46397de849b7566f3688823302e01",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "fledge.toml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "4452faf40f3454fe4f5f300b87d46ae49395e226b4fc26d0efb98dffa2e68f2a",
+        "entry_digest": "8463ed945de9fae3d4ebede29d7c0d9eaacd45b4adcffc9d649547f2085c8c61",
+        "owners": [
+          "@exact:delivery"
+        ]
+      }
+    ]
+  },
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout/approvals.json
+++ b/.specsync/changes/CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout/approvals.json
@@ -27,6 +27,13 @@
       "timestamp": 1783986541,
       "digest": "549accf61724a5ea8e2d01b90b34790d357e65647a28fb4eb166269c72ea3f06",
       "note": "Fresh closing approval after audited reopen and supported verification passed the native build and all 113 deterministic tests; the accepted definition and canonical spec are unchanged."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784415782,
+      "digest": "c116fc92cf1da1d06aac1abb148d59c692ed0ea1506b9adaa9d8bc3e7cea600a",
+      "note": "Re-acceptance with the Trust 1.1.1 and SpecSync 5.1.1 pins; canonical deltas were already integrated and were not replayed."
     }
   ],
   "reopenings": [
@@ -119,6 +126,51 @@
       },
       "stale_acceptance_input_digest": "14f925220223b5f614076863816355502bef4da7bab9def82f0115a27ded4c45",
       "current_acceptance_input_digest": "4e3bd8c3d3eb1634d08a7e27f73f55e93fb37987434c085bf10c45d5f8da4469"
+    },
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout",
+      "actor": "user:0xLeif",
+      "reason": "Trust 1.1.1 and SpecSync 5.1.1 pins changed governed delivery inputs; accepted verification is stale.",
+      "timestamp": 1784415639,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "user:0xLeif",
+        "timestamp": 1783986541,
+        "digest": "549accf61724a5ea8e2d01b90b34790d357e65647a28fb4eb166269c72ea3f06",
+        "note": "Fresh closing approval after audited reopen and supported verification passed the native build and all 113 deterministic tests; the accepted definition and canonical spec are unchanged."
+      },
+      "prior_verification": {
+        "timestamp": 1783986535,
+        "commit": "ed08f33e5df68d3cc5065f4501bc7126e47d0a36",
+        "contract_digest": "736ca999095211c18513988182d06c8abeca22b7ce77edc7d6d551b4e7084b63",
+        "workspace_digest": "fb540cb7bc51c79199a4d725ac2d53c55f24166bcc0f6e557fae4cd4903ae0ce",
+        "acceptance_input_digest": "4e3bd8c3d3eb1634d08a7e27f73f55e93fb37987434c085bf10c45d5f8da4469",
+        "passed": true,
+        "commands": [
+          {
+            "command": "fledge lanes run verify",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": [
+          "REQ-algokit-001",
+          "REQ-algokit-002",
+          "REQ-algokit-003",
+          "REQ-algokit-004",
+          "REQ-algokit-005",
+          "REQ-algokit-006",
+          "REQ-algokit-007",
+          "REQ-algokit-008",
+          "REQ-algokit-009",
+          "REQ-algokit-010"
+        ]
+      },
+      "stale_acceptance_input_digest": "4e3bd8c3d3eb1634d08a7e27f73f55e93fb37987434c085bf10c45d5f8da4469",
+      "current_acceptance_input_digest": "d3e253048b8da46afe71622ed300b8ce3fa06b02a7b868266c89424cb3df6bc7"
     }
   ]
 }

--- a/.specsync/changes/CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout/state.json
+++ b/.specsync/changes/CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout/state.json
@@ -9,7 +9,7 @@
   "canonical_applied": true,
   "base_commit": "4d0bb405eabcb48c1f748500d4b8d0ea6a15a583",
   "created_at": 1783982568,
-  "updated_at": 1783986541,
+  "updated_at": 1784415782,
   "affected_specs": [
     "algokit"
   ],

--- a/.specsync/changes/CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout/verification-attempts.json
+++ b/.specsync/changes/CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout/verification-attempts.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784415768,
+      "commit": "cf2ded7b3ae9f43f967a9dc19cd8b9b51ec7c1f4",
+      "contract_digest": "736ca999095211c18513988182d06c8abeca22b7ce77edc7d6d551b4e7084b63",
+      "workspace_digest": "5a5d84ec329ffc7c719f186cde2a0fdca0e5025e4f11bd2f7c77e943ce9195d4",
+      "passed": true,
+      "commands": [
+        {
+          "command": "fledge lanes run verify",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": [
+        "REQ-algokit-001",
+        "REQ-algokit-002",
+        "REQ-algokit-003",
+        "REQ-algokit-004",
+        "REQ-algokit-005",
+        "REQ-algokit-006",
+        "REQ-algokit-007",
+        "REQ-algokit-008",
+        "REQ-algokit-009",
+        "REQ-algokit-010"
+      ]
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout/verification.json
+++ b/.specsync/changes/CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout/verification.json
@@ -1,9 +1,214 @@
 {
-  "timestamp": 1783986535,
-  "commit": "ed08f33e5df68d3cc5065f4501bc7126e47d0a36",
+  "timestamp": 1784415768,
+  "commit": "cf2ded7b3ae9f43f967a9dc19cd8b9b51ec7c1f4",
   "contract_digest": "736ca999095211c18513988182d06c8abeca22b7ce77edc7d6d551b4e7084b63",
-  "workspace_digest": "fb540cb7bc51c79199a4d725ac2d53c55f24166bcc0f6e557fae4cd4903ae0ce",
-  "acceptance_input_digest": "4e3bd8c3d3eb1634d08a7e27f73f55e93fb37987434c085bf10c45d5f8da4469",
+  "workspace_digest": "5a5d84ec329ffc7c719f186cde2a0fdca0e5025e4f11bd2f7c77e943ce9195d4",
+  "acceptance_input_digest": "b0616961f399e921605b061673674546b1000b4d69dad795d0bedb54e506a5a6",
+  "acceptance_manifest": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "path": ".github/workflows/trust.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "b04cdee06d69a77377bb39a6ded1a944cf416f431b1feca2692eeed244e42813",
+        "entry_digest": "d8d38bfe82f88f14c72c0203d166be8b3f2f55ab9d50127f4ddee88f6e3a4df5",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".specsync/sdd.json",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "c92cbe18fbf227e4ae4d17ed96a35d646419813442aa39976cb279d3753143fd",
+        "entry_digest": "745759f40a076630bc7257f60d15b9071e986e91fbb5a1b018f191386019720b",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".trust.toml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "0ca37f8dc00590f9fa1acbbbc0819dd4c39d7968a49fe784b8180520a856a4de",
+        "entry_digest": "c97d671502e9908684fe170ba284831dac9caa819ed1d567b776187ec17fa77f",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AlgoKit+Account.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "5279f10a7cf6168f02af12f0aa01b2f24012f8cf32c71a0f13ed4b3e23361147",
+        "entry_digest": "71861995db78785ccf0d925ae69a73b76ca343bd3ad3a87bcc3849e77916fb5f",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AlgoKit+Application.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "87287b5b4b5ec0dd2fd3bd044cdce0f7213d692ca05b2781b9cf6e9b417385fd",
+        "entry_digest": "a2d3d7e8663bdcd842514e4c8587033362eab9f46dc59bedd306404cbcf4ec0d",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AlgoKit+Asset.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "23476d187d588539aeace263c3ecc2c788a97df481a4584c906832d2e33ff048",
+        "entry_digest": "f2161f023710304b4ac8eefca309000c955bbcf822026f3ff04e3545c1f213b6",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AlgoKit+Indexer.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "2b461ee6e62ca471745858514c76d5b02ed924b0e2fa2be7f6d0d31b8b7faac8",
+        "entry_digest": "09c34a935a1beb18213177691114c75037db700b0773da59d92ec56bbcb278ae",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AlgoKit+KeyRegistration.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "8a4850761b79009fd1601ea3037e99e9331fb7e4f8c18d1787ab040d0d5bea50",
+        "entry_digest": "20720c26ad1428fbfd4a67a02e696801defe0a6cbe748f90423a0ecbc07a4fda",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AlgoKit+Network.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "6587e715a6859619fe21983e8e2ed191db9fb4e86fe2683f29107e20673c064d",
+        "entry_digest": "dcae40c51b5f531773a8e85fcca2ff6f9ed1ef83c4b40a0b61cf701960f7cc81",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AlgoKit+Payment.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "c92be880096dca5db697ba285cb0749cb7ffee5c6c1416d7a3fda517bb70e1a5",
+        "entry_digest": "c6e56ff65b4ceb7c8544b50f6c82b648b3b76761c9400b86d44f5c4e3e00129c",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AlgoKit+Transaction.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "cef3b538462615664728187ed1c90101f244a355d2d188ca659795a2efc406c1",
+        "entry_digest": "de9b1b57901c68463fbfdd08a3a5b36da37152496cb8e700c67dceca5bfa73f7",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AlgoKit.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "bf7a03f16850b749f8562e31f7f4c135bf9037b63e33743e6989e42d3e71d676",
+        "entry_digest": "e29152cbda4cfbe9fc3b06ff3d1a068454a7222a1d0113793f897129470da437",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/AtomicTransactionComposer.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "92bbfd6c3631fab547b2b986194367fc30351147e7ca5ac4969f4f415da8b572",
+        "entry_digest": "4280c596e3f83ab9bbca329deab2fff55b88fd8712a29a3e7e7a76b91e2e12ea",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "Sources/AlgoKit/Extensions/MicroAlgos+Convenience.swift",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "b269ab5e4866f199ae9ab49e63f89eb8d7c09aefb97a06cc78942506683e19cb",
+        "entry_digest": "337450d6c34e55521b422e7ea20bd0160fcb1bb4d76e49bc194fc85709d75d0e",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "specs/algokit",
+        "kind": "non_file",
+        "mode": 0,
+        "payload_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "entry_digest": "1cc013eef40804b601344926942f5b2fb57682ca53ec294a1901e00115b071fb",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": "specs/algokit/algokit.spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "08b7354d257c016c412c25f68d6ace7798f8621888c9cb70fee2cb27fdea06ef",
+        "entry_digest": "cc75fd6af742d715b18134a975f566d9078b321001b0d5bc289499a0f8e73227",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "specs/algokit/context.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "02d5fde7252d34eb3e71c26e84709c9a85aa4b0bb203b514fa6033094e41164e",
+        "entry_digest": "096462fc19bfbc12e26bcd842ce1b740f281dcdbf8a16816096177eb749b36bd",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "specs/algokit/requirements.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "fddd464df125f005360520befd6b3fca9055c0bdf444db83547a679a9e23f999",
+        "entry_digest": "8785d241c14636d6f37e9779dce6e9fc4ffde5548e2e9236df5f16e61a1177ca",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "specs/algokit/tasks.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "82207aac74b7dea20aaced956cebb1118ea7522034b4af4ca9515942a8fd8dac",
+        "entry_digest": "b8609959a02423fe6cea0a32109a73df17a705fefd854da67efcf36c7145114f",
+        "owners": [
+          "algokit"
+        ]
+      },
+      {
+        "path": "specs/algokit/testing.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "59c5f84c0de59b4d39023a07e26234e6a28867fec90aa8f17abcea989a65a311",
+        "entry_digest": "d0cb7ba51206e1b71da9b96d0d003c0ed24c85c47639946729be7a342b5280b1",
+        "owners": [
+          "algokit"
+        ]
+      }
+    ]
+  },
   "passed": true,
   "commands": [
     {

--- a/.specsync/changes/CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v/approvals.json
+++ b/.specsync/changes/CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v/approvals.json
@@ -13,7 +13,49 @@
       "timestamp": 1783986558,
       "digest": "060ae7b1d53b2f8cd8c62fd0a001058c8568af2a4e03a4cd3c95495b7131d167",
       "note": "Accepted after supported verification confirmed the native build and all 113 deterministic tests; the change is limited to generated agent integrations and governance workflow ordering."
+    },
+    {
+      "gate": "acceptance",
+      "actor": "user:0xLeif",
+      "timestamp": 1784415811,
+      "digest": "a573dc635966f54a24866e45965684370465e98d79375425ebbb790cd522cd1f",
+      "note": "Re-acceptance with the Trust 1.1.1 and SpecSync 5.1.1 pins; canonical deltas were already integrated and were not replayed."
     }
   ],
-  "reopenings": []
+  "reopenings": [
+    {
+      "schema_version": 1,
+      "change_id": "CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v",
+      "actor": "user:0xLeif",
+      "reason": "Trust 1.1.1 and SpecSync 5.1.1 pins changed governed delivery inputs; accepted verification is stale.",
+      "timestamp": 1784415661,
+      "from_state": "accepted",
+      "to_state": "verifying",
+      "superseded_approval": {
+        "gate": "acceptance",
+        "actor": "user:0xLeif",
+        "timestamp": 1783986558,
+        "digest": "060ae7b1d53b2f8cd8c62fd0a001058c8568af2a4e03a4cd3c95495b7131d167",
+        "note": "Accepted after supported verification confirmed the native build and all 113 deterministic tests; the change is limited to generated agent integrations and governance workflow ordering."
+      },
+      "prior_verification": {
+        "timestamp": 1783986553,
+        "commit": "ed08f33e5df68d3cc5065f4501bc7126e47d0a36",
+        "contract_digest": "368e1bed5cfb15f84469c0a96b00f327cfb7f49c4a5023ca6fd5d037374d5f85",
+        "workspace_digest": "fb540cb7bc51c79199a4d725ac2d53c55f24166bcc0f6e557fae4cd4903ae0ce",
+        "acceptance_input_digest": "1b8118c6af0f970530e3c9bc065b6c0c51c0d6349473bd4923bde4c192ba41e4",
+        "passed": true,
+        "commands": [
+          {
+            "command": "fledge lanes run verify",
+            "success": true,
+            "exit_code": 0
+          }
+        ],
+        "requirement_ids": []
+      },
+      "stale_acceptance_input_digest": "1b8118c6af0f970530e3c9bc065b6c0c51c0d6349473bd4923bde4c192ba41e4",
+      "current_acceptance_input_digest": "05a9598ff6d3d1aa80f7f627738d8e6386dd726372fad427fa9bb35e34e23481"
+    }
+  ]
 }

--- a/.specsync/changes/CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v/state.json
+++ b/.specsync/changes/CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v/state.json
@@ -9,7 +9,7 @@
   "canonical_applied": true,
   "base_commit": "ed08f33e5df68d3cc5065f4501bc7126e47d0a36",
   "created_at": 1783986195,
-  "updated_at": 1783986558,
+  "updated_at": 1784415811,
   "affected_specs": [],
   "affected_paths": [
     ".claude/",

--- a/.specsync/changes/CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v/verification-attempts.json
+++ b/.specsync/changes/CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v/verification-attempts.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "attempts": [
+    {
+      "timestamp": 1784415797,
+      "commit": "cf2ded7b3ae9f43f967a9dc19cd8b9b51ec7c1f4",
+      "contract_digest": "368e1bed5cfb15f84469c0a96b00f327cfb7f49c4a5023ca6fd5d037374d5f85",
+      "workspace_digest": "5a5d84ec329ffc7c719f186cde2a0fdca0e5025e4f11bd2f7c77e943ce9195d4",
+      "passed": true,
+      "commands": [
+        {
+          "command": "fledge lanes run verify",
+          "success": true,
+          "exit_code": 0
+        }
+      ],
+      "requirement_ids": []
+    }
+  ]
+}

--- a/.specsync/changes/CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v/verification.json
+++ b/.specsync/changes/CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v/verification.json
@@ -1,9 +1,124 @@
 {
-  "timestamp": 1783986553,
-  "commit": "ed08f33e5df68d3cc5065f4501bc7126e47d0a36",
+  "timestamp": 1784415797,
+  "commit": "cf2ded7b3ae9f43f967a9dc19cd8b9b51ec7c1f4",
   "contract_digest": "368e1bed5cfb15f84469c0a96b00f327cfb7f49c4a5023ca6fd5d037374d5f85",
-  "workspace_digest": "fb540cb7bc51c79199a4d725ac2d53c55f24166bcc0f6e557fae4cd4903ae0ce",
-  "acceptance_input_digest": "1b8118c6af0f970530e3c9bc065b6c0c51c0d6349473bd4923bde4c192ba41e4",
+  "workspace_digest": "5a5d84ec329ffc7c719f186cde2a0fdca0e5025e4f11bd2f7c77e943ce9195d4",
+  "acceptance_input_digest": "7c195d1f46f1006347ba096ea15e69a77694a6d2209c116b66a946a77e39d87c",
+  "acceptance_manifest": {
+    "schema_version": 1,
+    "entries": [
+      {
+        "path": ".claude/commands/specsync/create-change.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "2aff55edbefcb38c67445385ec7abe24bccedf1d29f84076242dedec2ba9d7b1",
+        "entry_digest": "3e2a47058fcd3402b8b027ee5f0c1259cb68919c9b948b1f6a15813da6ba4e9e",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".claude/commands/specsync/create-spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "0c294e25f52b7f2b0765ce0dedfa8532cbb390998321155e8a540772a3f5927b",
+        "entry_digest": "eb968b45a1c4085562aed6e9c1374243b68f5dc9b7bd7c17aa9a00791e0c9614",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".claude/skills/spec-sync/SKILL.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "0db08a11daf93a661e53a0d576940447bbfdccce012c0362553cd1ee3702a1bf",
+        "entry_digest": "180e52280cc377a79aa1409c631fa301c9e44a55b538814a585b101f63ea3bef",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".codex/skills/spec-sync/SKILL.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "0db08a11daf93a661e53a0d576940447bbfdccce012c0362553cd1ee3702a1bf",
+        "entry_digest": "71290ca1a91119945d3e62e1ad125b447a7a555fe0a48d3a9a325c76bc003ed2",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".cursor/commands/specsync-create-change.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "6adb21afee9e568ef0290fda265436c9a5deaa8b8cc5010adf89ec2f290aaea4",
+        "entry_digest": "ff211024dd385782e10fc5de9fdd2a508cf70f63d94f904fc061e48a7d69513b",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".cursor/commands/specsync-create-spec.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "46c8a464311a34689c69b1454f92026735083d591c05782952b0b24f48b03bcf",
+        "entry_digest": "058ba152feb533de2769ce8cff5618da85f70dcbe0ff4acd80341cbc820696b0",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".cursor/skills/spec-sync/SKILL.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "0db08a11daf93a661e53a0d576940447bbfdccce012c0362553cd1ee3702a1bf",
+        "entry_digest": "51e07efad6eda16ccebff9f9509ebe4a7a7d8c586f4e2bc21e59e2ccda496c7e",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".gemini/commands/specsync/create-change.toml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "ec46f9f09f8e63948464a6cc528ab08ef84c7af0fde36c7241c507b53e3ca26f",
+        "entry_digest": "14b99bf43a35a90bf83327dffc9f42f94e6d8e3508d7b7e48025bfb35605db56",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".gemini/commands/specsync/create-spec.toml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "a8242e5bc3071b96519fbc69807aa6925126bf31461b18d43c0e3eb3292ca6bc",
+        "entry_digest": "04f1d8378f0212943fe454e014a00f323d5cb02ba4f2186a627c61f604afadc5",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".gemini/skills/spec-sync/SKILL.md",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "0db08a11daf93a661e53a0d576940447bbfdccce012c0362553cd1ee3702a1bf",
+        "entry_digest": "df5158c737c0abb71aa71bcd02bfb91182b06c69d0093bc148d630a3e0a86bce",
+        "owners": [
+          "@exact:delivery"
+        ]
+      },
+      {
+        "path": ".github/workflows/trust.yml",
+        "kind": "file",
+        "mode": 33188,
+        "payload_digest": "b04cdee06d69a77377bb39a6ded1a944cf416f431b1feca2692eeed244e42813",
+        "entry_digest": "d8d38bfe82f88f14c72c0203d166be8b3f2f55ab9d50127f4ddee88f6e3a4df5",
+        "owners": [
+          "@exact:delivery"
+        ]
+      }
+    ]
+  },
   "passed": true,
   "commands": [
     {


### PR DESCRIPTION
## Summary

Pins the governance workflow to the new immutable releases:

- `CorvidLabs/trust@9d32b5786d2e9e4d39fc581c0091c721ee3d4226 # v1.0.0` → `CorvidLabs/trust@a239f78658e5ad0f12fa230f494890e40c6e4d7b # v1.1.1`
- `CorvidLabs/spec-sync@59bbfa766c6cce01ab815ab47db195b0629cc014 # v5.0.1` → `CorvidLabs/spec-sync@a89d827e93fa0bc9e6168447e66a0ad30fa92e65 # v5.1.1`
- `version: 5.0.1` → `version: "5.1.1"`

Only `.github/workflows/trust.yml` was edited by hand; all `.specsync/` record updates were made by the SpecSync 5.1.1 CLI.

## Ledger migration

`python3 migrate_specsync_5_1_records.py .` output:

```
migrated 0 fields across 3 ledgers
```

No backfill was needed; the existing records already parse under 5.1.1.

## Changes re-accepted

The pin bump made the accepted verification of all three accepted changes stale (governed exact-only input `.github/workflows/trust.yml` changed). Each was put through the native reopen → verify → accept cycle:

- `CHG-0001-adopt-specsync-5-0-1-and-trust-1-0-0-governance-for-swift-algokit` — verify lane passed (113 tests, 0 failures), re-accepted
- `CHG-0002-document-the-existing-swift-algokit-api-at-complete-coverage-and-correct-rollout` — verify lane passed, re-accepted
- `CHG-0003-install-all-four-agent-integrations-and-order-the-standalone-specsync-workflow-v` — verify lane passed, re-accepted

Re-acceptance note on each: "Re-acceptance with the Trust 1.1.1 and SpecSync 5.1.1 pins; canonical deltas were already integrated and were not replayed."

## Final `specsync check`

Exit 0 — error-free:

```
✓ SDD lifecycle valid (3 active change(s))

  ⚠ specs/algokit/algokit.spec.md: requirements changed — spec may need re-validation
  ℹ specs/algokit/algokit.spec.md: companion file updated (hash refreshed)

1 specs checked: 1 passed, 1 warning(s), 0 failed
File coverage: 11/11 (100%)
LOC coverage:  1370/1370 (100%)
```

The remaining warning is informational (spec re-validation suggestion); there are no errors.

Not merging — leaving review/merge to maintainers.